### PR TITLE
feat(STATFLO-724): clean-up rename widgetType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statflo/widget-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SDK for building widgets with Statflo and beyond",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,7 +6,7 @@ export interface Widget {
   id: string;
   name: string;
   url: string;
-  widgetType: "iframe" | "native";
+  type: "iframe" | "native";
   remote?: {
     module: string;
     component: string;
@@ -72,7 +72,7 @@ const useWidgetStore = create<WidgetState>()((set, get) => {
       const { id, type, data } = e;
 
       get()
-        .widgets.filter((widget) => widget.widgetType === "iframe")
+        .widgets.filter((widget) => widget.type === "iframe")
         .forEach((widget) => {
           const iframe = document.getElementById(
             widget.id


### PR DESCRIPTION
Renamed `Widget.widgetType` to simply `Widget.type`. This is a potentiality breaking change but to the best of our knowledge that field isn't being used anywhere yet. I also tested the changes using the `/examples` which worked well.

