### PR TITLE
STATFLO-724: rename to native from remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statflo/widget-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SDK for building widgets with Statflo and beyond",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,11 +7,10 @@ export interface Widget {
   name: string;
   url: string;
   type: "iframe" | "native";
-  remote?: {
+  native?: {
     module: string;
     component: string;
   };
-  component?: string;
 }
 
 export interface WidgetState {


### PR DESCRIPTION
Renamed a few fields on the `Widget` type.
Renamed `widget.component` which isn't being used.
