### PR TITLE
feat(STATFLO-800): fix zustand warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import useWidgetStore from "@statflo/widget-sdk";
 
 ```typescript
 import useWidgetStore from "@statflo/widget-sdk";
-import create from "zustand";
+import { create } from "zustand";
 
 const useBoundWidgetStore = create(useWidgetStore);
 ```

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import "iframe-resizer-react";
-import create from "zustand";
+import { create } from "zustand";
 import "./App.css";
 
 import useWidgetStore, { WidgetEvent } from "@statflo/widget-sdk";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statflo/widget-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "SDK for building widgets with Statflo and beyond",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import create from "zustand/vanilla";
+import { createStore } from "zustand/vanilla";
 import "iframe-resizer/js/iframeResizer.contentWindow";
 
 export interface Widget {
@@ -37,7 +37,7 @@ export class WidgetEvent<T> {
   }
 }
 
-const useWidgetStore = create<WidgetState>()((set, get) => {
+const useWidgetStore = createStore<WidgetState>()((set, get) => {
   const listener = (event: MessageEvent) => {
     const { data } = event;
 


### PR DESCRIPTION
Version up to v0.4.3

Fixed two zustand warning: 
```
[DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand'`.
[DEPRECATED] Default export is deprecated. Instead use import { createStore } from 'zustand/vanilla'.
```

However, There is one zustand warning that could not be fixed yet because the warning comes from *store.d.ts* which is generated during the building step. We didn't find a easy solution for that and when chatting with @sicsol we agreed to look into this issue later.

Remaining warning message:
```
[DEPRECATED] Passing a vanilla store will be unsupported in a future version. Instead use `import { useStore } from 'zustand'`.
```
Generated *store.d.ts*:
```
declare const useWidgetStore: import("zustand/vanilla").StoreApi<WidgetState>;
```

