### PR TITLE
Statflo-723 - Improvement : rename remote field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statflo/widget-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "SDK for building widgets with Statflo and beyond",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,8 +8,8 @@ export interface Widget {
   url: string;
   type: "iframe" | "native";
   native?: {
+    remote: string;
     module: string;
-    component: string;
   };
 }
 


### PR DESCRIPTION
We renamed to `widget.native.remote` from `widget.native.component` in order to better align with Module Federation naming convention.

I also tested `examples/react` and `examples/vanilla` and they worked as expected.